### PR TITLE
Setup for snapcraft building

### DIFF
--- a/snap/local/patches/X001-default_data_dir.patch
+++ b/snap/local/patches/X001-default_data_dir.patch
@@ -1,7 +1,7 @@
---- a/src/util.cpp	2021-07-02 14:00:05.384677604 +0100
-+++ b/src/util.cpp	2021-07-02 14:02:18.761271092 +0100
+--- a/src/util.cpp	2021-07-16 14:05:25.916474113 +0100
++++ b/src/util.cpp	2021-07-16 14:08:16.343511483 +0100
 @@ -671,7 +671,7 @@
-     return GetSpecialFolderPath(CSIDL_APPDATA) / "Bytz";
+     return GetSpecialFolderPath(CSIDL_APPDATA) / "Bytzcoin";
  #else
      fs::path pathRet;
 -    char* pszHome = getenv("HOME");
@@ -9,4 +9,3 @@
      if (pszHome == nullptr || strlen(pszHome) == 0)
          pathRet = fs::path("/");
      else
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2021 The Bytz Core developers
 name: bytz
 base: core18
-version: 0.2.99
+version: 0.2.0.0
 summary:   bytz, digital currency for media content
 description: |
   BYTZ is an open-source decentralized peer-to-peer currency featuring a Delegated Proof of Stake algorithm
@@ -29,7 +29,7 @@ description: |
   - twitter (https://twitter.com/bytzcurrency)
   - instagram (https://www.instagram.com/bytzcurrency/)
   - facebook (https://www.facebook.com/bytzcurrency)
-grade: devel
+grade: stable
 confinement: strict
 apps:
   daemon:
@@ -99,7 +99,7 @@ parts:
   bytz:
     source: http://github.com/bytzcurrency/bytz
     source-type: git
-    source-tag: develop
+    source-tag: v0.2.0.0
     plugin: nil
     override-build: |
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
We can now set up for snapcraft building against the repo to make bytz publicly available to nearly every linux distribution through snap on 4 processors amd64, i686, arn32 and arm64