### PR TITLE
Set snapcraft to build from master

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,7 +99,7 @@ parts:
   bytz:
     source: http://github.com/bytzcurrency/bytz
     source-type: git
-    source-tag: v0.2.0.0
+    source-tag: master
     plugin: nil
     override-build: |
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
Snapcraft was building from v0.2.0.0 .. this branch does not have the latest patch for util.cpp