### PR TITLE
[GUI] Update unlock for staking interface

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -62,7 +62,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent) :
             ui->passEdit2->hide();
             ui->passLabel3->hide();
             ui->passEdit3->hide();
-            setWindowTitle(tr("Unlock wallet for mixing and staking only"));
+            setWindowTitle(tr("Unlock wallet for staking only"));
             break;
         case Unlock: // Ask passphrase
             ui->warningLabel->setText(tr("This operation needs your wallet passphrase to unlock the wallet."));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -430,6 +430,8 @@ void BitcoinGUI::createActions()
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
     unlockWalletAction = new QAction(tr("&Unlock Wallet..."), this);
     unlockWalletAction->setToolTip(tr("Unlock wallet"));
+    unlockWalletForStakingAction = new QAction(tr("Unlock Wallet for &Staking..."), this);
+    unlockWalletForStakingAction->setToolTip(tr("Unlock the wallet for staking only"));
     lockWalletAction = new QAction(tr("&Lock Wallet"), this);
     signMessageAction = new QAction(tr("Sign &message..."), this);
     signMessageAction->setStatusTip(tr("Sign messages with your Bytz addresses to prove you own them"));
@@ -507,6 +509,7 @@ void BitcoinGUI::createActions()
         connect(backupWalletAction, SIGNAL(triggered()), walletFrame, SLOT(backupWallet()));
         connect(changePassphraseAction, SIGNAL(triggered()), walletFrame, SLOT(changePassphrase()));
         connect(unlockWalletAction, SIGNAL(triggered()), walletFrame, SLOT(unlockWallet()));
+        connect(unlockWalletForStakingAction, SIGNAL(triggered()), walletFrame, SLOT(unlockWalletForStaking()));
         connect(lockWalletAction, SIGNAL(triggered()), walletFrame, SLOT(lockWallet()));
         connect(signMessageAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
         connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
@@ -556,6 +559,7 @@ void BitcoinGUI::createMenuBar()
         settings->addAction(encryptWalletAction);
         settings->addAction(changePassphraseAction);
         settings->addAction(unlockWalletAction);
+        settings->addAction(unlockWalletForStakingAction);
         settings->addAction(lockWalletAction);
         settings->addSeparator();
     }
@@ -1677,6 +1681,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         labelWalletEncryptionIcon->setToolTip(tr("Wallet is <b>unencrypted</b>"));
         changePassphraseAction->setEnabled(false);
         unlockWalletAction->setVisible(false);
+        unlockWalletForStakingAction->setVisible(false);
         lockWalletAction->setVisible(false);
         encryptWalletAction->setEnabled(true);
         break;
@@ -1686,6 +1691,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         labelWalletEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently <b>unlocked</b>"));
         changePassphraseAction->setEnabled(true);
         unlockWalletAction->setVisible(false);
+        unlockWalletForStakingAction->setVisible(false);
         lockWalletAction->setVisible(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
         break;
@@ -1695,6 +1701,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         labelWalletEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently <b>unlocked</b> for staking and mixing only"));
         changePassphraseAction->setEnabled(true);
         unlockWalletAction->setVisible(true);
+        unlockWalletForStakingAction->setVisible(true);
         lockWalletAction->setVisible(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
         break;
@@ -1704,6 +1711,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         labelWalletEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently <b>locked</b>"));
         changePassphraseAction->setEnabled(true);
         unlockWalletAction->setVisible(true);
+        unlockWalletForStakingAction->setVisible(true);
         lockWalletAction->setVisible(false);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
         break;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -129,6 +129,7 @@ private:
     QAction *backupWalletAction;
     QAction *changePassphraseAction;
     QAction *unlockWalletAction;
+    QAction *unlockWalletForStakingAction;
     QAction *lockWalletAction;
     QAction *aboutQtAction;
     QAction *openInfoAction;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -209,6 +209,13 @@ void WalletFrame::unlockWallet()
         walletView->unlockWallet();
 }
 
+void WalletFrame::unlockWalletForStaking()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->unlockWallet(true);
+}
+
 void WalletFrame::lockWallet()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -86,6 +86,8 @@ public Q_SLOTS:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
+    /** Ask for passphrase to unlock wallet temporarily for staking only */
+    void unlockWalletForStaking();
     /** Lock wallet */
     void lockWallet();
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -359,6 +359,11 @@ void WalletView::unlockWallet(bool fForMixingOnly)
     }
 }
 
+void WalletView::unlockWalletForStaking()
+{
+    unlockWallet(true);
+}
+
 void WalletView::lockWallet()
 {
     if(!walletModel)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -106,6 +106,8 @@ public Q_SLOTS:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet(bool fAnonymizeOnly=false);
+    /** Ask for passphrase to unlock wallet temporarily for staking only */
+    void unlockWalletForStaking();
     /** Lock wallet */
     void lockWallet();
 


### PR DESCRIPTION
- Add menu item 'Settings/Unlock Wallet for Staking'
- getstakingstatus now respects 'unlocked for staking' status
- Help text on walletpassphrase refers to staking, not mixing