### PR TITLE
Update snapcraft config to build v0.2.0.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2021 The Bytz Core developers
 name: bytz
 base: core18
-version: 0.2.0.0
+version: 0.2.0.1
 summary:   bytz, digital currency for media content
 description: |
   BYTZ is an open-source decentralized peer-to-peer currency featuring a Delegated Proof of Stake algorithm
@@ -99,7 +99,7 @@ parts:
   bytz:
     source: http://github.com/bytzcurrency/bytz
     source-type: git
-    source-tag: master
+    source-tag: v0.2.0.1
     plugin: nil
     override-build: |
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
As there is an imminent update coming snapcraft.yaml needs to point at the new tag to build the snaps.