### PR TITLE
Update circleci to use new images, split out to cached depends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   lint_all:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     parallelism: 4
     environment:
@@ -43,15 +43,51 @@ jobs:
             git subtree add --prefix src/univalue univalue 9f0b9975925b202ab130714e5422f8dd8bf40ac3 --squash
             # snap
             source .circleci/lint_06_script.sh
-  x86_64_bionic:
+  x86_64_bionic_depends:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: x86_64-linux-gnu
       JOBS: 4
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-bionic-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/x86_64-linux-gnu ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 gcc-8 g++-8 libpython3.6-dev python3-distutils
+              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
+              update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+              update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
+              update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-bionic-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/x86_64-linux-gnu
+            - /root/project/depends/work
+  x86_64_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: x86_64-linux-gnu
+      JOBS: 4
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-bionic-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -61,25 +97,61 @@ jobs:
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
             update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
             update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends/${HOST} --enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
             make -j${JOBS}
+            apt-get -y install libfontconfig1
             make -j${JOBS} check
             git clone http://github.com/bytzcurrency/bytz_hash
             cd bytz_hash
             python3 setup.py install
             cd -
             test/functional/test_runner.py
-  x86_64_focal:
+  x86_64_focal_depends:
     docker:
-      - image: circleci/buildpack-deps:focal
+      - image: cimg/base:stable-20.04
         user: root
     environment:
       HOST: x86_64-linux-gnu
       JOBS: 4
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-focal-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/x86_64-linux-gnu ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 gcc-8 g++-8 libpython3.9-dev python3-distutils
+              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
+              update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+              update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
+              update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-focal-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/x86_64-linux-gnu
+            - /root/project/depends/work
+  x86_64_focal:
+    docker:
+      - image: cimg/base:stable-20.04
+        user: root
+    environment:
+      HOST: x86_64-linux-gnu
+      JOBS: 4
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-focal-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -89,19 +161,52 @@ jobs:
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
             update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
             update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends/${HOST} --enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
             make -j${JOBS}
-  i686_bionic:
+  i686_bionic_depends:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: i686-linux-gnu
       JOBS: 4
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-i686-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/i686-linux-gnu ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 g++-8-multilib gcc-8-multilib gcc-8 g++-8
+              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
+              update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-i686-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/i686-linux-gnu
+            - /root/project/depends/work
+  i686_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: i686-linux-gnu
+      JOBS: 4
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-i686-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -109,13 +214,12 @@ jobs:
             apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 g++-8-multilib gcc-8-multilib gcc-8 g++-8
             update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends/${HOST} --enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
             make -j${JOBS}
-  arm32_bionic:
+  arm32_bionic_depends:
     docker:
-      - image: ioncoin/gitian:latest
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: arm-linux-gnueabihf
@@ -123,6 +227,43 @@ jobs:
       HOST_LDFLAGS: "-static-libstdc++"
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-arm32-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/arm-linux-gnueabihf ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 gcc-8 g++-8 g++-8-arm-linux-gnueabihf gcc-8-arm-linux-gnueabihf binutils-arm-linux-gnueabihf g++-8-multilib gcc-8-multilib
+              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
+              update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+              update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
+              update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-arm32-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/arm-linux-gnueabihf
+            - /root/project/depends/work
+  arm32_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: arm-linux-gnueabihf
+      JOBS: 4
+      HOST_LDFLAGS: "-static-libstdc++"
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-arm32-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -132,19 +273,54 @@ jobs:
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
             update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
             update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends//${HOST} --enable-glibc-back-compat --enable-reduce-exports --disable-ccache --disable-maintainer-mode --disable-dependency-tracking CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
             make -j${JOBS}
-  arm64_bionic:
+  arm64_bionic_depends:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: aarch64-linux-gnu
       JOBS: 4
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-arm64-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/aarch64-linux-gnu ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 gcc-8 g++-8 g++-8-aarch64-linux-gnu gcc-8-aarch64-linux-gnu binutils-aarch64-linux-gnu g++-8-multilib gcc-8-multilib
+              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
+              update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+              update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
+              update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-arm64-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/aarch64-linux-gnu
+            - /root/project/depends/work
+  arm64_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: aarch64-linux-gnu
+      JOBS: 4
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-arm64-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -154,19 +330,52 @@ jobs:
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
             update-alternatives --install /usr/bin/${HOST}-gcc ${HOST}-gcc /usr/bin/${HOST}-gcc-8 100
             update-alternatives --install /usr/bin/${HOST}-g++ ${HOST}-g++ /usr/bin/${HOST}-g++-8 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends/${HOST} --enable-glibc-back-compat --enable-reduce-exports
             make -j${JOBS}
-  win32_bionic:
+  win32_bionic_depends:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: i686-w64-mingw32
       JOBS: 4
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-win32-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/i686-w64-mingw32 ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 mingw-w64 g++-mingw-w64 g++-multilib gcc-multilib
+              update-alternatives --install /usr/bin/i686-w64-mingw32-gcc i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix 100
+              update-alternatives --install /usr/bin/i686-w64-mingw32-g++ i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-win32-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/i686-w64-mingw32
+            - /root/project/depends/work
+  win32_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: i686-w64-mingw32
+      JOBS: 4
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-win32-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -174,19 +383,52 @@ jobs:
             apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 mingw-w64 g++-mingw-w64 g++-multilib gcc-multilib
             update-alternatives --install /usr/bin/i686-w64-mingw32-gcc i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix 100
             update-alternatives --install /usr/bin/i686-w64-mingw32-g++ i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends/${HOST} --enable-reduce-exports
             make -j${JOBS}
-  win64_bionic:
+  win64_bionic_depends:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: x86_64-w64-mingw32
       JOBS: 4
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-win64-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+            if [ -d depends/x86_64-w64-mingw32 ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 mingw-w64 g++-mingw-w64 g++-multilib gcc-multilib
+              update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
+              update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-win64-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/x86_64-w64-mingw32
+            - /root/project/depends/work
+  win64_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: x86_64-w64-mingw32
+      JOBS: 4
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-win64-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
@@ -194,13 +436,12 @@ jobs:
             apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 mingw-w64 g++-mingw-w64 g++-multilib gcc-multilib
             update-alternatives --install /usr/bin/x86_64-w64-mingw32-gcc x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix 100
             update-alternatives --install /usr/bin/x86_64-w64-mingw32-g++ x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 100
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             ./configure --host=${HOST} --prefix=`pwd`/depends/${HOST} --enable-reduce-exports
             make -j${JOBS}
-  mac_bionic:
+  mac_bionic_depends:
     docker:
-      - image: circleci/buildpack-deps:18.04
+      - image: cimg/base:stable-18.04
         user: root
     environment:
       HOST: x86_64-apple-darwin16
@@ -208,16 +449,50 @@ jobs:
       OSX_SDK: 10.11
     steps:
       - checkout
+      - restore_cache:
+          keys: 
+          - bytz-mac-depends-{{ .Branch }}-{{ .Revision }}
+      - run:
+          command: |
+           if [ -d depends/x86_64-apple-darwin16 ]; then
+              exit
+            else
+              git submodule update --init --recursive
+              apt-get -y update
+              apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 librsvg2-bin libtiff-tools imagemagick libcap-dev libz-dev libbz2-dev python3-dev python3-setuptools fonts-tuffy g++-8-multilib gcc-8-multilib
+              wget https://github.com/gitianuser/MacOSX-SDKs/releases/download/MacOSX10.11.sdk/MacOSX10.11.sdk.tar.xz
+              mkdir -p `pwd`/depends/SDKs
+              echo "Extracting Mac SDK"
+              tar -C `pwd`/depends/SDKs -xJf ./MacOSX10.11.sdk.tar.xz
+              make -j${JOBS} -C depends HOST=${HOST}
+            fi
+      - save_cache:
+          key: bytz-mac-depends-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /root/project/depends/built
+            - /root/project/depends/sources
+            - /root/project/depends/x86_64-apple-darwin16
+            - /root/project/depends/work
+            - /root/project/depends/SDKs
+  mac_bionic:
+    docker:
+      - image: cimg/base:stable-18.04
+        user: root
+    environment:
+      HOST: x86_64-apple-darwin16
+      JOBS: 4
+      OSX_SDK: 10.11
+    steps:
+      - checkout
+      - restore_cache:
+          keys: 
+          - bytz-mac-depends-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
             git submodule update --init --recursive
             apt-get -y update
             apt-get -y install pkg-config autoconf libtool automake bsdmainutils ca-certificates python3 cmake libxkbcommon0 librsvg2-bin libtiff-tools imagemagick libcap-dev libz-dev libbz2-dev python3-dev python3-setuptools fonts-tuffy g++-8-multilib gcc-8-multilib
             wget https://github.com/gitianuser/MacOSX-SDKs/releases/download/MacOSX10.11.sdk/MacOSX10.11.sdk.tar.xz
-            mkdir -p `pwd`/depends/SDKs
-            echo "Extracting Mac SDK"
-            tar -C `pwd`/depends/SDKs -xJf ./MacOSX10.11.sdk.tar.xz
-            make -j${JOBS} -C depends HOST=${HOST}
             ./autogen.sh
             CONFIG_SITE=`pwd`/depends/${HOST}/share/config.site ./configure --host=${HOST} --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking --enable-reduce-exports --disable-bench --disable-gui-tests --enable-crash-hooks
             make -j${JOBS}
@@ -226,27 +501,51 @@ workflows:
   FullCheck:
     jobs:
       - lint_all
+      - x86_64_bionic_depends:
+          requires:
+            - lint_all
       - x86_64_bionic:
+          requires:
+            - x86_64_bionic_depends
+      - i686_bionic_depends:
           requires:
             - lint_all
       - i686_bionic:
           requires:
+            - i686_bionic_depends
+      - x86_64_focal_depends:
+          requires:
             - lint_all
       - x86_64_focal:
+          requires:
+            - x86_64_focal_depends
+      - arm32_bionic_depends:
           requires:
             - lint_all
       - arm32_bionic:
           requires:
+            - arm32_bionic_depends
+      - arm64_bionic_depends:
+          requires:
             - lint_all
       - arm64_bionic:
+          requires:
+            - arm64_bionic_depends
+      - win32_bionic_depends:
           requires:
             - lint_all
       - win32_bionic:
           requires:
+            - win32_bionic_depends
+      - win64_bionic_depends:
+          requires:
             - lint_all
       - win64_bionic:
+          requires:
+            - win64_bionic_depends
+      - mac_bionic_depends:
           requires:
             - lint_all
       - mac_bionic:
           requires:
-            - lint_all
+            - mac_bionic_depends


### PR DESCRIPTION
- Circleci "circleci" images are being removed from production 12/31/21 have updated the circleci build scripts  with the new "cimg" images.  
- circleci now has 400000 build credits/month but run time is limited to an hour so have split out the make depends from the main build 